### PR TITLE
Failed to show hold call when user click swap and merge simultaneously

### DIFF
--- a/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
+++ b/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
@@ -1602,6 +1602,7 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
             fgImsCall.merge(bgImsCall);
         } catch (ImsException e) {
             log("conference " + e.getMessage());
+            handleConferenceFailed(foregroundConnection, backgroundConnection);
         }
     }
 
@@ -4602,5 +4603,16 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
     @Override
     public ImsPhone getPhone() {
         return mPhone;
+    }
+
+    private void handleConferenceFailed(ImsPhoneConnection fgConnection,
+            ImsPhoneConnection bgConnection) {
+        if (fgConnection != null) {
+            fgConnection.handleMergeComplete();
+        }
+        if (bgConnection != null) {
+            bgConnection.handleMergeComplete();
+        }
+        mPhone.notifySuppServiceFailed(Phone.SuppService.CONFERENCE);
     }
 }


### PR DESCRIPTION
Set EVENT_MERGE_START for foregroundConnection and backgroundConnection
but don't set EVENT_MERGE_COMPLETE when there is ImsException

Bug: 121105030
Change-Id: I08c189b976227ada1298a864f6f4ba70c4ffb7f9
Signed-off-by: Anushek Prasal <anushekprasal@gmail.com>